### PR TITLE
Report unused member expression dependencies

### DIFF
--- a/dist/cjs/rules/no-unused-deps.cjs
+++ b/dist/cjs/rules/no-unused-deps.cjs
@@ -7,6 +7,18 @@
 
 const reactNamespace = 'React';
 const hookNames = ['useEffect', 'useLayoutEffect'];
+
+/**
+ * Resolves the identifier a dependency is rooted in, so that member expression dependencies such as
+ * `props.value` can be checked against the identifiers the hook body references.
+ */
+const rootIdentifier = node => {
+  let current = node;
+  while (current.type === 'MemberExpression') {
+    current = current.object;
+  }
+  return current.type === 'Identifier' ? current : undefined;
+};
 const matchHooks = (name, {
   pattern,
   replace
@@ -79,16 +91,18 @@ const rule = {
       const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
       const through = scope.through.map(r => r.identifier.name);
       const depArray = parent.arguments[1];
-      const deps = depArray.elements.filter(e => (e == null ? void 0 : e.type) === 'Identifier');
+      const deps = depArray.elements.filter(e => (e == null ? void 0 : e.type) === 'Identifier' || (e == null ? void 0 : e.type) === 'MemberExpression');
       const unusedDeps = [];
       for (const dep of deps) {
-        if (through.includes(dep.name)) continue;
+        const root = rootIdentifier(dep);
+        // a computed root, such as `getItem().value`, cannot be traced back to an identifier
+        if (!root || through.includes(root.name)) continue;
         if (sourceCode.getCommentsBefore(dep).some(({
           value
         }) => value.includes(effectComment))) {
           continue;
         }
-        unusedDeps.push(dep.name);
+        unusedDeps.push(sourceCode.getText(dep));
       }
       if (unusedDeps.length > 0) {
         context.report({

--- a/rules/no-unused-deps.ts
+++ b/rules/no-unused-deps.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Rule, Scope, SourceCode } from 'eslint';
+import type { Identifier, Node } from 'estree';
 
 type RuleOption = {
   effectComment?: string;
@@ -12,6 +13,19 @@ type RuleOption = {
 
 const reactNamespace = 'React';
 const hookNames = ['useEffect', 'useLayoutEffect'];
+
+/**
+ * Resolves the identifier a dependency is rooted in, so that member expression dependencies such as
+ * `props.value` can be checked against the identifiers the hook body references.
+ */
+const rootIdentifier = (node: Node): Identifier | undefined => {
+  let current = node;
+  while (current.type === 'MemberExpression') {
+    current = current.object;
+  }
+
+  return current.type === 'Identifier' ? current : undefined;
+};
 
 const matchHooks = (
   name: string,
@@ -100,10 +114,14 @@ const rule: Rule.RuleModule = {
         : (context as unknown as { getScope: () => Scope.Scope }).getScope();
       const through = scope.through.map((r) => r.identifier.name);
       const depArray = parent.arguments[1];
-      const deps = depArray.elements.filter((e) => e?.type === 'Identifier');
+      const deps = depArray.elements.filter(
+        (e) => e?.type === 'Identifier' || e?.type === 'MemberExpression'
+      );
       const unusedDeps = [];
       for (const dep of deps) {
-        if (through.includes(dep.name)) continue;
+        const root = rootIdentifier(dep);
+        // a computed root, such as `getItem().value`, cannot be traced back to an identifier
+        if (!root || through.includes(root.name)) continue;
         if (
           sourceCode
             .getCommentsBefore(dep)
@@ -112,7 +130,7 @@ const rule: Rule.RuleModule = {
           continue;
         }
 
-        unusedDeps.push(dep.name);
+        unusedDeps.push(sourceCode.getText(dep));
       }
 
       if (unusedDeps.length > 0) {

--- a/tests/rules/no-unused-deps.js
+++ b/tests/rules/no-unused-deps.js
@@ -38,6 +38,33 @@ ruleTester.run('no-unused-deps', /** @type {import('eslint').Rule.RuleModule} */
       R.useEffect(() => {
         document.title = usedVar;
       }, [usedVar, effectVar]);
+    `,
+    `
+      useEffect(() => {
+          document.title = props.title;
+      }, [props.title]);
+    `,
+    `
+      useEffect(() => {
+          document.title = props.title;
+      }, [props.title, /* effect dep */ props.version]);
+    `,
+    `
+      useEffect(() => {
+          document.title = a.b.c;
+      }, [a.b.c]);
+    `,
+    // the hook body references the same root, so a sibling member dependency is not reported
+    `
+      useEffect(() => {
+          document.title = props.title;
+      }, [props.version]);
+    `,
+    // a dependency that is not rooted in an identifier cannot be traced
+    `
+      useEffect(() => {
+          document.title = usedVar;
+      }, [getItem().value]);
     `
   ],
 
@@ -65,6 +92,39 @@ ruleTester.run('no-unused-deps', /** @type {import('eslint').Rule.RuleModule} */
         }, [usedVar, unusedVar, /* effect dep */ effectVar]);
       `,
       errors: [getError("'unusedVar'")]
+    },
+    {
+      code: `
+        useEffect(() => {
+            document.title = usedVar;
+        }, [usedVar, unusedProps.value]);
+      `,
+      errors: [getError("'unusedProps.value'")]
+    },
+    {
+      code: `
+        useEffect(() => {
+            document.title = usedVar;
+        }, [usedVar, unusedProps.a.b]);
+      `,
+      errors: [getError("'unusedProps.a.b'")]
+    },
+    {
+      code: `
+        useEffect(() => {
+            document.title = usedVar;
+        }, [usedVar, unusedProps.value, /* effect dep */ effectProps.value]);
+      `,
+      errors: [getError("'unusedProps.value'")]
+    },
+    {
+      code: `
+        useEffect(() => {
+            const shadowedProps = usedVar;
+            document.title = shadowedProps.value;
+        }, [usedVar, shadowedProps.value]);
+      `,
+      errors: [getError("'shadowedProps.value'")]
     },
     {
       code: `


### PR DESCRIPTION
Dependency array elements were filtered to `Identifier` nodes, so a dependency written as a member expression was never checked. This is easy to hit when narrowing a dependency, e.g. going from `[item]` to `[item.id]` silently opts the dependency out of the rule.

Member expressions are now checked via the identifier they are rooted in, and reported with their full source text. Two cases are deliberately not reported:

- a dependency whose root is not an identifier, such as `getItem().value`, since it cannot be traced to a binding
- a sibling member of a root the hook body already references, e.g. `[props.version]` where the body reads `props.title` - `scope.through` only records the root identifier

The existing `/* effect dep */` marker works on member expressions too.